### PR TITLE
docs: add Canada student internships resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ this is in no way an endorsement of any of these programs, organizations, or the
 
 ### Tech internships but not cybersecurity specific
 
+* [Hanzilla Jobs - Canada student internships/co-ops](https://jobs.hanzilla.co/internships/) - Daily-updated Canadian student/recent-grad jobs board with internships, co-ops, new grad, junior, and entry-level roles across tech/software plus finance, engineering, business, sciences, and more.
 * IBM
   * [Associate Developer Intern 2026](https://ibmglobal.avature.net/en_US/careers/JobDetail?jobId=58077&source=WEB_Search_NA), Sandy Springs, Brookhaven, Houston, Austin, Chicago, Georgia, Illinois, Texas, United States
   * [Associate Designer Intern 2026](https://ibmglobal.avature.net/en_US/careers/JobDetail?jobId=57353&source=WEB_Search_NA), Sandy Springs, Brookhaven, Austin, Chicago, Georgia, Illinois, Texas, United States


### PR DESCRIPTION
## Summary

Adds Hanzilla Jobs as a Canada-specific companion resource under the non-cyber-specific tech internships section.

Why this may help students using this list:
- Hanzilla Jobs is a free daily-updated Canadian student/recent-grad jobs board.
- The linked internships page focuses on internships/co-ops and also covers new grad, junior, and entry-level roles across tech/software plus finance, engineering, business, sciences, and more.
- This is intended as a supplemental Canada-focused resource, not a replacement for the cybersecurity-specific internship links already in the README.

Link added: https://jobs.hanzilla.co/internships/

## Validation

- Verified the linked page returns HTTP 200.
- Verified it is indexable/no accidental `noindex`.
- Markdown-only change.
